### PR TITLE
Clean up in Reports Notebook

### DIFF
--- a/ifrs17-template/Report/Reports.ipynb
+++ b/ifrs17-template/Report/Reports.ipynb
@@ -99,7 +99,7 @@
                 "\npv.CurrencyType = CurrencyType.Contractual;",
                 "\npv.ColumnSlices = new string[]{};//\"GroupOfContract\", \"AmountType\"",
                 "\npv.DataFilter = null; //new [] {(\"GroupOfContract\", \"DT1.2\"),(\"LiabilityType\", \"LIC\") };",
-                "\n(await pv.ToReportAsync) with {Height = 720}"
+                "\n(await pv.ToReportAsync)"
             ],
             "metadata": {},
             "execution_count": 0,
@@ -126,7 +126,7 @@
                 "\nra.ReportingPeriod = (2021, 3);",
                 "\nra.ColumnSlices = new string[]{};//\"GroupOfContract\", \"EconomicBasis\"",
                 "\nra.DataFilter = null;//new [] {(\"GroupOfContract\", \"DT1.2\")};",
-                "\n(await ra.ToReportAsync) with {Height = 800}"
+                "\n(await ra.ToReportAsync)"
             ],
             "metadata": {},
             "execution_count": 0,
@@ -154,7 +154,7 @@
                 "\nwrittenActual.ReportingPeriod = (2021, 3);",
                 "\nwrittenActual.ColumnSlices = new string[]{};//\"GroupOfContract\"",
                 "\nwrittenActual.DataFilter =  null; //new [] {(\"GroupOfContract\", \"DT1.1\")};",
-                "\n(await writtenActual.ToReportAsync) with {Height = 400}"
+                "\n(await writtenActual.ToReportAsync)"
             ],
             "metadata": {},
             "execution_count": 0,
@@ -182,7 +182,7 @@
                 "\naccrualActual.ReportingPeriod = (2021, 3);",
                 "\naccrualActual.ColumnSlices = new string[]{};//\"GroupOfContract\", \"AmountType\"",
                 "\naccrualActual.DataFilter = null; //new [] {(\"EstimateType\", \"AA\")};",
-                "\n(await accrualActual.ToReportAsync) with {Height = 400}"
+                "\n(await accrualActual.ToReportAsync)"
             ],
             "metadata": {},
             "execution_count": 0,
@@ -207,7 +207,7 @@
                 "\ndeferrableActual.ReportingPeriod = (2021, 3);",
                 "\ndeferrableActual.ColumnSlices = new string[]{};//\"GroupOfContract\", \"AmountType\"",
                 "\ndeferrableActual.DataFilter = null;//new [] {(\"GroupOfContract\", \"DT1.1\")};",
-                "\n(await deferrableActual.ToReportAsync) with {Height = 400}"
+                "\n(await deferrableActual.ToReportAsync)"
             ],
             "metadata": {},
             "execution_count": 0,
@@ -236,7 +236,7 @@
                 "\nfulfillmentCashflows.ReportingPeriod = (2021, 3);",
                 "\nfulfillmentCashflows.ColumnSlices = new string[]{};//\"EstimateType\"",
                 "\nfulfillmentCashflows.DataFilter = null;// new [] {(\"GroupOfContract\", \"DT1.1\")};",
-                "\n(await fulfillmentCashflows.ToReportAsync) with {Height = 750}"
+                "\n(await fulfillmentCashflows.ToReportAsync)"
             ],
             "metadata": {},
             "execution_count": 0,
@@ -261,7 +261,7 @@
                 "\nexperienceAdjustments.ReportingPeriod = (2021, 3);",
                 "\nexperienceAdjustments.ColumnSlices = new string[]{};//\"GroupOfContract\", \"AmountType\"",
                 "\nexperienceAdjustments.DataFilter = null; //new [] {(\"GroupOfContract\", \"DT1.1\")};",
-                "\n(await experienceAdjustments.ToReportAsync) with {Height = 300}"
+                "\n(await experienceAdjustments.ToReportAsync)"
             ],
             "metadata": {},
             "execution_count": 0,
@@ -287,7 +287,7 @@
                 "\ntechnicalMargins.ReportingPeriod = (2021, 3);",
                 "\ntechnicalMargins.ColumnSlices = new string[]{};//\"GroupOfContract\", \"AmountType\"",
                 "\ntechnicalMargins.DataFilter = null; //new [] {(\"GroupOfContract\", \"DT1.1\")};",
-                "\n(await technicalMargins.ToReportAsync) with {Height = 600}"
+                "\n(await technicalMargins.ToReportAsync)"
             ],
             "metadata": {},
             "execution_count": 0,
@@ -314,7 +314,7 @@
                 "\nallocatedTechnicalMargins.ReportingPeriod = (2021, 3);",
                 "\nallocatedTechnicalMargins.ColumnSlices = new string[]{};//\"GroupOfContract\", \"EstimateType\"",
                 "\nallocatedTechnicalMargins.DataFilter = null; //new [] {(\"GroupOfContract\", \"DT1.1\")};",
-                "\n(await allocatedTechnicalMargins.ToReportAsync) with {Height = 700}"
+                "\n(await allocatedTechnicalMargins.ToReportAsync)"
             ],
             "metadata": {},
             "execution_count": 0,
@@ -339,7 +339,7 @@
                 "\nactuarialLrc.ReportingPeriod = (2021, 3);",
                 "\nactuarialLrc.ColumnSlices = new string[]{};//\"GroupOfContract\"",
                 "\nactuarialLrc.DataFilter = null; //new [] {(\"GroupOfContract\", \"DT1.1\")};",
-                "\n(await actuarialLrc.ToReportAsync) with {Height = 750}"
+                "\n(await actuarialLrc.ToReportAsync)"
             ],
             "metadata": {},
             "execution_count": 0,
@@ -364,7 +364,7 @@
                 "\nlrc.ReportingPeriod = (2021, 3);",
                 "\nlrc.ColumnSlices = new string[]{};//\"GroupOfContract\",",
                 "\nlrc.DataFilter = null; //new [] {(\"GroupOfContract\", \"DT1.1\")};",
-                "\n(await lrc.ToReportAsync) with {Height = 250}"
+                "\n(await lrc.ToReportAsync)"
             ],
             "metadata": {},
             "execution_count": 0,
@@ -389,7 +389,7 @@
                 "\nactuarialLic.ReportingPeriod = (2021, 3);",
                 "\nactuarialLic.ColumnSlices = new string[]{};//\"GroupOfContract\", \"AmountType\"",
                 "\nactuarialLic.DataFilter = null; //new [] {(\"GroupOfContract\", \"DT1.1\")};",
-                "\n(await actuarialLic.ToReportAsync) with {Height = 750}"
+                "\n(await actuarialLic.ToReportAsync)"
             ],
             "metadata": {},
             "execution_count": 0,
@@ -414,7 +414,7 @@
                 "\nlic.ReportingPeriod = (2021, 3);",
                 "\nlic.ColumnSlices = new string[]{};//\"GroupOfContract\", \"AmountType\"",
                 "\nlic.DataFilter = null; //new [] {(\"GroupOfContract\", \"DT1.1\")};",
-                "\n(await lic.ToReportAsync) with {Height = 250}"
+                "\n(await lic.ToReportAsync)"
             ],
             "metadata": {},
             "execution_count": 0,
@@ -441,7 +441,7 @@
                 "\nfinancialPerformance.ReportingPeriod = (2021, 3);",
                 "\nfinancialPerformance.ColumnSlices = new string[]{};//\"GroupOfContract\"",
                 "\nfinancialPerformance.DataFilter = null; //new [] {(\"GroupOfContract\", \"DT1.1\")};",
-                "\n(await financialPerformance.ToReportAsync) with { Height = 900, GroupDefaultExpanded = 3}"
+                "\n(await financialPerformance.ToReportAsync) with {GroupDefaultExpanded = 3}"
             ],
             "metadata": {},
             "execution_count": 0,


### PR DESCRIPTION
Remove `with { Height }` from Reports, since an automatic height feature has been added.